### PR TITLE
Make Windows path work on fake Windows

### DIFF
--- a/spec/classes/windows_spec.rb
+++ b/spec/classes/windows_spec.rb
@@ -1,6 +1,19 @@
 require 'spec_helper'
 
-
 describe 'windows' do 
-  it { should compile } 
+  context "on Windows" do
+    let :facts do
+      { :kernel => "windows" }
+    end
+
+    it { should compile }
+  end
+
+  context "on Linux" do
+    let :facts do
+      { :kernel => "Linux" }
+    end
+
+    it { should_not compile }
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,5 +5,24 @@ fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 RSpec.configure do |c|
   c.module_path  = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.before :each do
+    Puppet[:autosign] = true # Change autosign from being posix path, which breaks Puppet when we're pretending to be on Windows
+
+    f = self.respond_to?(:facts) ? facts : {} # Work even if you don't specify facts
+    Thread.current[:windows?] = lambda { f[:kernel] == "windows" } # Automatically detect whether we're pretending to run on Windows
+  end
+end
+
+module Puppet
+  module Util
+    module Platform
+      def self.windows?
+        # This is where Puppet normally looks for the target OS.
+        # It normally returns the *current* OS (i.e., not Windows,
+        # if you're not running the specs on Windows)
+        !!Thread.current[:windows?].call
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
Added a hack to override Puppet's OS detection, based on the `kernel`
fact, as set in the test. Normally Puppet assumes (in some places where
it doesn't have access to the target OS's facts) that it is targetting
the OS that the specs are running on, not the OS specified by the facts
in the spec. Should work around rodjek/rspec-puppet#192 , though there
are more problems like this when using the `compile` matchers in specs
targetting Windows (e.g. packages want the `msi` provider to be
available).
